### PR TITLE
Replaced the deprecated optparse with argparse

### DIFF
--- a/util.py
+++ b/util.py
@@ -2,8 +2,33 @@ import sys
 import binascii
 import re
 
+
+# The standard (IEEE 802) format for printing MAC-48 addresses
+# in human-friendly form is six groups of two hexadecimal digits,
+# separated by "-" hyphens or ":" colons. In order to extract
+# this from input by REGEX_HEX12, first remove hyphens/colons.
+REGEX_HEX12 = re.compile('^([0-9A-F]{12})$')
+
+
+def normalize_address(address, ignore=':-'):
+    """
+    Normalize given address in uppercase mac-address with colons.
+    Returns given address formatted like 'DE:AD:BE:EF:01:02'
+    or an empty string if the given address doesn't match.
+    """
+    address = address.strip().upper()
+    for c in ignore:
+        address = address.replace(c, '')
+    m = REGEX_HEX12.match(address)
+    if m:
+        address = m.group(0)
+        return ':'.join(address[i:i + 2] for i in range(0, 12, 2))
+    return ''
+
+
 def bytes_to_uint32_le(bytes):
     return  (int(bytes[3], 16) << 24) | (int(bytes[2], 16) << 16) | (int(bytes[1], 16) <<  8) | (int(bytes[0], 16) <<  0)
+
 
 def uint32_to_bytes_le(uint32):
     return [(uint32 >> 0)  & 0xff, 
@@ -11,13 +36,16 @@ def uint32_to_bytes_le(uint32):
             (uint32 >> 16) & 0xff, 
             (uint32 >> 24) & 0xff]
 
+
 def uint16_to_bytes_le(value):
     return [(value >> 0 & 0xFF),
             (value >> 8 & 0xFF)]
 
+
 def zero_pad_array_le(data, padsize):
     for i in range(0, padsize):
         data.insert(0, 0)
+
 
 def array_to_hex_string(arr):
     hex_str = ""
@@ -25,33 +53,33 @@ def array_to_hex_string(arr):
         if val > 255:
             raise Exception("Value is greater than it is possible to represent with one byte")
         hex_str += "%02x" % val
-
     return hex_str
+
 
 def crc32_unsigned(bytestring):
     return binascii.crc32(bytestring) % (1 << 32)
 
+
 def mac_string_to_uint(mac):
     parts = list(re.match('(..):(..):(..):(..):(..):(..)', mac).groups())
     ints = map(lambda x: int(x, 16), parts)
-
     res = 0
     for i in range(0, len(ints)):
         res += (ints[len(ints)-1 - i] << 8*i)
-
     return res
+
 
 def uint_to_mac_string(mac):
     ints = [0, 0, 0, 0, 0, 0]
     for i in range(0, len(ints)):
         ints[len(ints)-1 - i] = (mac >> 8*i) & 0xff
-
     return ':'.join(map(lambda x: '{:02x}'.format(x).upper(), ints))
 
-# Print a nice console progress bar
+
 def print_progress(iteration, total, prefix = '', suffix = '', decimals = 1, barLength = 100):
     """
-    Call in a loop to create terminal progress bar
+    Print a nice console progress bar.
+    Call in a loop to provide a console progress bar.
     @params:
         iteration   - Required  : current iteration (Int)
         total       - Required  : total iterations (Int)


### PR DESCRIPTION
Working towards Python 3 compatibility (see #4), this PR replaces the use of the `optparse` module (deprecated since Python 3.2) with the `argparse` module available in both Python 2 and 3. The command line interface has also been expanded with more detail (see `python dfu.py --help` for details).

In the process made the address argument mandatory and more flexible (by adding a parsing/normalizing method for MAC-addresses to the project's `util.py`).

Please do check whether the tool still works, I've separated this PR out from more future changes; but lacked time to properly test all aspects.