### PR TITLE
Made name of the check_dfu_mode() method all lowercase

### DIFF
--- a/ble_legacy_dfu_controller.py
+++ b/ble_legacy_dfu_controller.py
@@ -184,7 +184,7 @@ class BleDfuControllerLegacy(NrfBleDfuController):
     #  Check if the peripheral is running in bootloader (DFU) or application mode
     #  Returns True if the peripheral is in DFU mode
     # --------------------------------------------------------------------------
-    def check_DFU_mode(self):
+    def check_dfu_mode(self):
         if verbose: print "Checking DFU State..."
 
         cmd = 'char-read-uuid %s' % self.UUID_VERSION

--- a/ble_secure_dfu_controller.py
+++ b/ble_secure_dfu_controller.py
@@ -103,7 +103,7 @@ class BleDfuControllerSecure(NrfBleDfuController):
     #  Check if the peripheral is running in bootloader (DFU) or application mode
     #  Returns True if the peripheral is in DFU mode
     # --------------------------------------------------------------------------
-    def check_DFU_mode(self):
+    def check_dfu_mode(self):
         print "Checking DFU State..."
 
         self.ble_conn.sendline('characteristics')

--- a/dfu.py
+++ b/dfu.py
@@ -142,7 +142,7 @@ def main():
 
         # Connect to peer device. Assume application mode.
         if ble_dfu.scan_and_connect():
-            if not ble_dfu.check_DFU_mode():
+            if not ble_dfu.check_dfu_mode():
                 print "Need to switch to DFU mode"
                 success = ble_dfu.switch_to_dfu_mode()
                 if not success:

--- a/nrf_ble_dfu_controller.py
+++ b/nrf_ble_dfu_controller.py
@@ -31,7 +31,7 @@ class NrfBleDfuController(object):
     #  Returns True if the peripheral is in DFU mode
     # --------------------------------------------------------------------------
     @abstractmethod
-    def check_DFU_mode(self):
+    def check_dfu_mode(self):
         pass
 
     @abstractmethod


### PR DESCRIPTION
Renamed the (old) `check_DFU_mode()` method name to the all lowercase `check_dfu_mode()` method name in the whole project, to be more consistent with the other method names used.